### PR TITLE
Create the ~/.worklog directory if it does not exist

### DIFF
--- a/worklog.py
+++ b/worklog.py
@@ -358,6 +358,8 @@ class Worklog( MutableSequence ):
         return value
 
     def save( self ):
+        directory = os.path.split( self.persist_path )[0]
+        os.makedirs( directory, mode=755 )
         with open( self.persist_path, 'w' ) as json_file:
             json.dump( self.store, json_file, cls = KlassEncoder, indent = 4 )
 


### PR DESCRIPTION
As the title says, make sure the directory exists before writing to it. 