### PR TITLE
Don't run os.makedirs() if the directory already exists

### DIFF
--- a/worklog.py
+++ b/worklog.py
@@ -359,7 +359,8 @@ class Worklog( MutableSequence ):
 
     def save( self ):
         directory = os.path.split( self.persist_path )[0]
-        os.makedirs( directory, mode=755 )
+        if not os.access( directory, os.F_OK ):
+            os.makedirs( directory, mode=755 )
         with open( self.persist_path, 'w' ) as json_file:
             json.dump( self.store, json_file, cls = KlassEncoder, indent = 4 )
 


### PR DESCRIPTION
Sorry, I didn't realize os.makedirs() throws an error when the directory already exists.